### PR TITLE
use single quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ script:
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
-      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
+      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email '$SHED_EMAIL' --shed_password '$SHED_PASSWORD' --force_repository_creation '$DIR' || exit 1; done < changed_repositories_chunk.list
+      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email '$SHED_EMAIL' --shed_password '$SHED_PASSWORD' --force_repository_creation '$DIR' || exit 1; done < changed_repositories_chunk.list
     fi


### PR DESCRIPTION
use single quotes for `$SHED_PASSWORD` in travis (I randomly generated password, and we're getting this error in travis output: `/home/travis/build.sh: line 57: G*4%G96Sa: command not found` which I think is a result of this


