### PR TITLE
add reminder to check toolshed access rights

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@ Please sign off by admins only
   - [ ] Test files are appropriate
 * [ ] `<command/>`: file names are escaped
 * [ ] Tool requires version/build increase
-
+* [ ] Toolshed user `erasmusmc` has access to associated toolshed repo(s)


### PR DESCRIPTION
Reminder toevoegen om access rights in toolshed te checken

Please sign off by admins only
------------------------------

* [ ] Has no duplicate (otherwise merge required)
* [ ] Indentation is correct
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] `<command/>`: file names are escaped
* [ ] Tool requires version/build increase


