### PR TITLE
fix case where no samples were lost

### DIFF
--- a/tools/mycrobiota/recover_samples_discarded_by_subsample.xml
+++ b/tools/mycrobiota/recover_samples_discarded_by_subsample.xml
@@ -19,17 +19,17 @@
         &&
         if [ -z "\$samples"];
             then
-                touch fasta.pick.dat;
-                touch group.pick.dat;
+                cp fasta2.dat final_fasta;
+                cp group2.dat final_group;
             else
                 echo "get.groups(fasta=fasta.dat, group=group.dat, groups=\$samples)" | sed 's/ //g' | mothur;
+
+                ## merge selected reads (fasta.pick.dat) with the fasta file from after sub.sample
+                echo "merge.files(input=fasta2.dat-fasta.pick.dat, output=final_fasta)" | sed 's/ //g' | mothur;
+
+                ## merge group files
+                echo "merge.files(input=group2.dat-group.pick.dat, output=final_group)" | sed 's/ //g' | mothur;
         fi
-
-        ## merge selected reads (fasta.pick.dat) with the fasta file from after sub.sample
-        && echo "merge.files(input=fasta2.dat-fasta.pick.dat, output=final_fasta)" | sed 's/ //g' | mothur
-
-        ## merge group files
-        && echo "merge.files(input=group2.dat-group.pick.dat, output=final_group)" | sed 's/ //g' | mothur
 
     ]]></command>
     <inputs>
@@ -52,6 +52,15 @@
             <param name="threshold" value="3"/>
             <output name="out_fasta" file="recovered.fasta"/>
             <output name="out_group" file="recovered.groups"/>
+        </test>
+        <test><!-- test case where nothing was discarded -->
+            <param name="in_fasta" value="fasta_before_subsample_small.fasta" ftype="fasta"/>
+            <param name="in_fasta_subsampled" value="fasta_after_subsample_small.fasta" ftype="fasta"/>
+            <param name="in_group" value="groups_before_subsample_small.groups" ftype="mothur.groups"/>
+            <param name="in_group_subsampled" value="groups_after_subsample_small.groups" ftype="mothur.groups"/>
+            <param name="threshold" value="1"/>
+            <output name="out_fasta" file="fasta_after_subsample_small.fasta"/>
+            <output name="out_group" file="groups_after_subsample_small.groups"/>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/erasmusmc-bioinformatics/galaxytools-emc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `erasmus-medical-center` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
