### PR TITLE
Add Pathway viewer tool

### DIFF
--- a/tools/pathway-viewer/.shed.yml
+++ b/tools/pathway-viewer/.shed.yml
@@ -4,8 +4,7 @@ categories:
   - Sequence Analysis
 description: Visualize Pathway enrichment
 long_description: |
-    Longer tool description
-    newlines are okay
-remote_repository_url: https://github.com/project/repository
-homepage_url: http://www.example.org
+    Visualize Pathways based on differential expression data
+remote_repository_url: https://github.com/ErasmusMC-Bioinformatics/galaxytools-emc/tree/master/tools/pathway-viewer
+homepage_url: https://www.wikipathways.org/index.php/PathwayWidget
 type: unrestricted

--- a/tools/pathway-viewer/.shed.yml
+++ b/tools/pathway-viewer/.shed.yml
@@ -2,7 +2,7 @@ name: pathway-viewer
 owner: erasmus-medical-center
 categories:
   - Sequence Analysis
-description: Tool description
+description: Visualize Pathway enrichment
 long_description: |
     Longer tool description
     newlines are okay

--- a/tools/pathway-viewer/.shed.yml
+++ b/tools/pathway-viewer/.shed.yml
@@ -1,0 +1,11 @@
+name: pathway-viewer
+owner: erasmus-medical-center
+categories:
+  - Sequence Analysis
+description: Tool description
+long_description: |
+    Longer tool description
+    newlines are okay
+remote_repository_url: https://github.com/project/repository
+homepage_url: http://www.example.org
+type: unrestricted

--- a/tools/pathway-viewer/pathwayviewer.xml
+++ b/tools/pathway-viewer/pathwayviewer.xml
@@ -30,9 +30,9 @@ Rscript '$__tool_directory__/view_pathway.R'
         </test>
     </tests>
     <help><![CDATA[
-help text goes here
-    ]]></help>5
+Pathway visualisation
+    ]]></help>
     <citations>
-        <citation type="doi">42.4242/42</citation>
+        <citation type="doi">10.1093/nar/gkx1064</citation>
     </citations>
 </tool>

--- a/tools/pathway-viewer/pathwayviewer.xml
+++ b/tools/pathway-viewer/pathwayviewer.xml
@@ -1,0 +1,38 @@
+<tool id="pathway_viewer" name="Pathway Viewer" version="0.1" profile="16.07">
+    <description>visualize differentially expressed genes on a pathway</description>
+    <requirements>
+        <requirement type="package" version="1.98_1.2">r-rcurl</requirement>
+        <requirement type="package" version="2.10.0">bioconductor-rcy3</requirement>
+        <requirement type="package" version="1.1_2">r-rcolorbrewer</requirement>
+        <requirement type="package" version="1.10.0">bioconductor-rwikipathways</requirement>
+        <requirement type="package" version="1.6.6">r-optparse</requirement>
+    </requirements>
+    <command detect_errors="aggressive"><![CDATA[
+Rscript '$__tool_directory__/view_pathway.R'
+  --wikiPathway '$wikipathway'
+  --header $header
+  --genes '$genes'
+    ]]></command>
+    <inputs>
+        <param name="genes" type="data" format="tabular" label="List of Differentially expressed genes" />
+        <param name="wikipathway" type="text" value="WP528" label="wikiPathway ID" help="IDs must start with WP"/>
+        <param name="header" type="boolean" truevalue="TRUE" falsevalue="FALSE" checked="true" label="Does the file have a header line?" />
+    </inputs>
+    <outputs>
+       <data name="pathwayview" format="html" from_work_dir="pathwayview.html" label="${tool.name} on ${on_string}: Pathway View"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="genes" value="deg.tsv" ftype="tabular"/>
+            <param name="headers" value="TRUE"/>
+            <param name="wikiPathway" value="WP528"/>
+            <output name="pathwayview" file="pathwayview.html" ftype="html"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+help text goes here
+    ]]></help>5
+    <citations>
+        <citation type="doi">42.4242/42</citation>
+    </citations>
+</tool>

--- a/tools/pathway-viewer/test-data/deg.tsv
+++ b/tools/pathway-viewer/test-data/deg.tsv
@@ -1,0 +1,5 @@
+gene	fc	pvalue	adj.-pvalue
+pemt	1	0	0
+pdha1	-5	0	0
+ache	2	0	0
+chka	-2	0	0

--- a/tools/pathway-viewer/test-data/pathwayview.html
+++ b/tools/pathway-viewer/test-data/pathwayview.html
@@ -1,0 +1,617 @@
+<html><body>
+<style>
+svg.Diagram {
+  width: 100%;
+  height: 100%;
+}
+</style>
+<style>#HGNC_PEMT .Icon, .HGNC_PEMT .Icon, [name="HGNC_PEMT"] .Icon { fill: #ffdada;}
+#HGNC_PEMT.Edge path, .HGNC_PEMT.Edge path { stroke: #ffdada;}
+#HGNC_PDHA1 .Icon, .HGNC_PDHA1 .Icon, [name="HGNC_PDHA1"] .Icon { fill: #4646ff;}
+#HGNC_PDHA1.Edge path, .HGNC_PDHA1.Edge path { stroke: #4646ff;}
+#HGNC_CHKA .Icon, .HGNC_CHKA .Icon, [name="HGNC_CHKA"] .Icon { fill: #b5b5ff;}
+#HGNC_CHKA.Edge path, .HGNC_CHKA.Edge path { stroke: #b5b5ff;}
+#HGNC_ACHE .Icon, .HGNC_ACHE .Icon, [name="HGNC_ACHE"] .Icon { fill: #ffb5b5;}
+#HGNC_ACHE.Edge path, .HGNC_ACHE.Edge path { stroke: #ffb5b5;}
+</style>
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" prefix="schema:http://schema.org/" id="wp528-svg" version="1.1" baseProfile="full" preserveAspectRatio="xMidYMid" color="black" class="Diagram" viewBox="0 0 829.0515247108307 621.8666666666666" width="800px" height="600px" vocab="http://vocabularies.wikipathways.org/wp#">
+  <style type="text/css"><![CDATA[
+]]></style>
+  <defs>
+    <g id="jit-defs">
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaaviowhitetofffffffilter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="1  0  0 0 -1                  0  1  0 0 -1                  0  0  1 0 -1                  0  0  0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaavioblacktofffffffilter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="-1   0   0 0 1                   0  -1   0 0 1                   0   0  -1 0 1                   0   0   0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaaviowhiteto000000filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="1  0  0 0 -0                  0  1  0 0 -0                  0  0  1 0 -0                  0  0  0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaavioblackto000000filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="-1   0   0 0 0                   0  -1   0 0 0                   0   0  -1 0 0                   0   0   0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaaviowhiteto0000fffilter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="1  0  0 0 -0                  0  1  0 0 -0                  0  0  1 0 -1                  0  0  0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaavioblackto0000fffilter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="-1   0   0 0 0                   0  -1   0 0 0                   0   0  -1 0 1                   0   0   0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaaviowhitetob4b464filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="1  0  0 0 -0.7058823529411765                  0  1  0 0 -0.7058823529411765                  0  0  1 0 -0.39215686274509803                  0  0  0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaavioblacktob4b464filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="-1   0   0 0 0.7058823529411765                   0  -1   0 0 0.7058823529411765                   0   0  -1 0 0.39215686274509803                   0   0   0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaaviowhiteto808080filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="1  0  0 0 -0.5019607843137255                  0  1  0 0 -0.5019607843137255                  0  0  1 0 -0.5019607843137255                  0  0  0 1 0"/>
+      </filter>
+      <filter x="0" y="0" height="621.8666666666666" width="829.0515247108307" id="kaavioblackto808080filter" filterUnits="userSpaceOnUse">
+        <feColorMatrix type="matrix" in="SourceGraphic" values="-1   0   0 0 0.5019607843137255                   0  -1   0 0 0.5019607843137255                   0   0  -1 0 0.5019607843137255                   0   0   0 1 0"/>
+      </filter>
+    </g>
+    <g id="jic-defs">
+      <clipPath id="ClipPathRoundedRectangle" clipPathUnits="objectBoundingBox">
+        <rect width="1" height="1" rx=".125" ry=".25"/>
+      </clipPath>
+      <filter id="BlackToRed" width="100%" height="100%" x="0" y="0" filterUnits="userSpaceOnUse">
+        <feComponentTransfer>
+          <feFuncR intercept="1" type="linear"/>
+          <feFuncG intercept="1" slope="-1" type="linear"/>
+          <feFuncB intercept="1" slope="-1" type="linear"/>
+        </feComponentTransfer>
+      </filter>
+      <filter id="BlackToGreen" width="100%" height="100%" x="0" y="0" filterUnits="userSpaceOnUse">
+        <feComponentTransfer>
+          <feFuncR intercept="1" type="linear"/>
+          <feFuncG intercept="1" slope="-1" type="linear"/>
+          <feFuncB intercept="1" slope="-1" type="linear"/>
+        </feComponentTransfer>
+      </filter>
+      <filter id="Invert100" width="200%" height="200%" x="-100%" y="-100%" filterUnits="userSpaceOnUse">
+        <feColorMatrix in="SourceGraphic" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"/>
+      </filter>
+      <filter id="Invert95" width="200%" height="200%" x="-50%" y="-50%" filterUnits="userSpaceOnUse">
+        <feComponentTransfer>
+          <feFuncR tableValues="1 0.05" type="table"/>
+          <feFuncG tableValues="1 0.05" type="table"/>
+          <feFuncB tableValues="1 0.05" type="table"/>
+        </feComponentTransfer>
+      </filter>
+      <filter id="WhiteTo33BFFF" width="100%" height="100%" x="0" y="0" filterUnits="userSpaceOnUse">
+        <feColorMatrix in="SourceGraphic" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0"/>
+      </filter>
+      <filter id="WhiteToRed" width="100%" height="100%" x="0" y="0" filterUnits="userSpaceOnUse">
+        <feComponentTransfer>
+          <feFuncR type="linear"/>
+          <feFuncG intercept="1" slope="-.95" type="linear"/>
+          <feFuncB intercept="1" slope="-1" type="linear"/>
+        </feComponentTransfer>
+      </filter>
+      <filter id="WhiteToGreen" width="100%" height="100%" x="0" y="0" filterUnits="userSpaceOnUse">
+        <feComponentTransfer>
+          <feFuncR intercept="1" slope="-1" type="linear"/>
+          <feFuncG type="linear"/>
+          <feFuncB intercept="1" slope="-.95" type="linear"/>
+        </feComponentTransfer>
+      </filter>
+      <marker id="markerArrow" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartArrow" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidArrow" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndArrow" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMimBinding" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 12L0 6l12-6-7 6z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartMimBinding" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 12L0 6l12-6-7 6z" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidMimBinding" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 12L0 6l12-6-7 6z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndMimBinding" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 12L0 6l12-6-7 6z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMimCatalysis" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <circle cx="6" cy="6" r="5.3" fill="none" stroke="#000" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerStartMimCatalysis" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <circle cx="6" cy="6" r="5.3" fill="none" stroke="#000"/>
+      </marker>
+      <marker id="markerMidMimCatalysis" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <circle cx="6" cy="6" r="5.3" fill="none" stroke="#000" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerEndMimCatalysis" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <circle cx="6" cy="6" r="5.3" fill="none" stroke="#000" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerMimCleavage" stroke-dasharray="99999" markerHeight="30" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="10" refY="15" viewBox="0 0 20 30">
+        <g stroke="#000" transform="rotate(180 10 15)">
+          <path d="M18 14.5V30M18 30L0 0"/>
+        </g>
+      </marker>
+      <marker id="markerStartMimCleavage" stroke-dasharray="99999" markerHeight="30" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="0" refY="15" viewBox="0 0 20 30">
+        <g stroke="#000">
+          <path d="M18 14.5V30M18 30L0 0"/>
+        </g>
+      </marker>
+      <marker id="markerMidMimCleavage" stroke-dasharray="99999" markerHeight="30" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="10" refY="15" viewBox="0 0 20 30">
+        <g stroke="#000" transform="rotate(180 10 15)">
+          <path d="M18 14.5V30M18 30L0 0"/>
+        </g>
+      </marker>
+      <marker id="markerEndMimCleavage" stroke-dasharray="99999" markerHeight="30" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="20" refY="15" viewBox="0 0 20 30">
+        <g stroke="#000" transform="rotate(180 10 15)">
+          <path d="M18 14.5V30M18 30L0 0"/>
+        </g>
+      </marker>
+      <marker id="markerMimConversion" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartMimConversion" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidMimConversion" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndMimConversion" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M12 11L0 6l12-5z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMimCovalentBond" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path fill="none" stroke="#000" d="M11 1H1v10h10"/>
+      </marker>
+      <marker id="markerStartMimCovalentBond" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path fill="none" stroke="#000" d="M11 1H1v10h10" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerMidMimCovalentBond" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path fill="none" stroke="#000" d="M11 1H1v10h10"/>
+      </marker>
+      <marker id="markerEndMimCovalentBond" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path fill="none" stroke="#000" d="M11 1H1v10h10"/>
+      </marker>
+      <marker id="markerMimGap" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path fill="none" d="M0 5.3h8v1.4H0z" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerStartMimGap" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path fill="none" d="M0 5.3h8v1.4H0z"/>
+      </marker>
+      <marker id="markerMidMimGap" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path fill="none" d="M0 5.3h8v1.4H0z" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerEndMimGap" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path fill="none" d="M0 5.3h8v1.4H0z" transform="rotate(180 6 6)"/>
+      </marker>
+      <marker id="markerMimInhibition" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="5" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartMimInhibition" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="0" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" transform="rotate(180 5 10)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidMimInhibition" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="5" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndMimInhibition" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="10" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <marker id="markerMimModification" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M0 6l11 5V1z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartMimModification" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M0 6l11 5V1z" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidMimModification" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M0 6l11 5V1z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndMimModification" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <path stroke-width="0" d="M0 6l11 5V1z" transform="rotate(180 6 6)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMimNecessaryStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="16" orient="auto" preserveAspectRatio="none" refX="8" refY="6" viewBox="0 0 16 12">
+        <g fill="none" transform="rotate(180 8 6)">
+          <path stroke="#000" d="M14 0v12"/>
+          <path d="M16 6"/>
+          <path stroke="#000" d="M0 6l9 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerStartMimNecessaryStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="16" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 16 12">
+        <g fill="none">
+          <path stroke="#000" d="M14 0v12"/>
+          <path d="M16 6"/>
+          <path stroke="#000" d="M0 6l9 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerMidMimNecessaryStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="16" orient="auto" preserveAspectRatio="none" refX="8" refY="6" viewBox="0 0 16 12">
+        <g fill="none" transform="rotate(180 8 6)">
+          <path stroke="#000" d="M14 0v12"/>
+          <path d="M16 6"/>
+          <path stroke="#000" d="M0 6l9 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerEndMimNecessaryStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="16" orient="auto" preserveAspectRatio="none" refX="16" refY="6" viewBox="0 0 16 12">
+        <g fill="none" transform="rotate(180 8 6)">
+          <path stroke="#000" d="M14 0v12"/>
+          <path d="M16 6"/>
+          <path stroke="#000" d="M0 6l9 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerMimStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <g fill="none" transform="rotate(180 6 6)">
+          <path d="M12 6"/>
+          <path stroke="#000" d="M0 6l11 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerStartMimStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="0" refY="6" viewBox="0 0 12 12">
+        <g fill="none">
+          <path d="M12 6"/>
+          <path stroke="#000" d="M0 6l11 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerMidMimStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="6" refY="6" viewBox="0 0 12 12">
+        <g fill="none" transform="rotate(180 6 6)">
+          <path d="M12 6"/>
+          <path stroke="#000" d="M0 6l11 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerEndMimStimulation" stroke-dasharray="99999" markerHeight="12" markerUnits="userSpaceOnUse" markerWidth="12" orient="auto" preserveAspectRatio="none" refX="12" refY="6" viewBox="0 0 12 12">
+        <g fill="none" transform="rotate(180 6 6)">
+          <path d="M12 6"/>
+          <path stroke="#000" d="M0 6l11 5V1z"/>
+        </g>
+      </marker>
+      <marker id="markerMimTranscriptionTranslation" stroke-dasharray="99999" markerHeight="24" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="10" refY="12" viewBox="0 0 20 24">
+        <g fill="none" stroke="#000" transform="rotate(180 10 12)">
+          <path d="M15 12V5M15.5 5H8M0 5l8-4v8z"/>
+        </g>
+      </marker>
+      <marker id="markerStartMimTranscriptionTranslation" stroke-dasharray="99999" markerHeight="24" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="0" refY="12" viewBox="0 0 20 24">
+        <g fill="none" stroke="#000">
+          <path d="M15 12V5M15.5 5H8M0 5l8-4v8z"/>
+        </g>
+      </marker>
+      <marker id="markerMidMimTranscriptionTranslation" stroke-dasharray="99999" markerHeight="24" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="10" refY="12" viewBox="0 0 20 24">
+        <g fill="none" stroke="#000" transform="rotate(180 10 12)">
+          <path d="M15 12V5M15.5 5H8M0 5l8-4v8z"/>
+        </g>
+      </marker>
+      <marker id="markerEndMimTranscriptionTranslation" stroke-dasharray="99999" markerHeight="24" markerUnits="userSpaceOnUse" markerWidth="20" orient="auto" preserveAspectRatio="none" refX="20" refY="12" viewBox="0 0 20 24">
+        <g fill="none" stroke="#000" transform="rotate(180 10 12)">
+          <path d="M15 12V5M15.5 5H8M0 5l8-4v8z"/>
+        </g>
+      </marker>
+      <marker id="markerTBar" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="5" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <marker id="markerStartTBar" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="0" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" transform="rotate(180 5 10)" fill="currentColor"/>
+      </marker>
+      <marker id="markerMidTBar" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="5" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <marker id="markerEndTBar" stroke-dasharray="99999" markerHeight="20" markerUnits="userSpaceOnUse" markerWidth="10" orient="auto" preserveAspectRatio="none" refX="10" refY="10" viewBox="0 0 10 20">
+        <path stroke="currentColor" d="M3 0v20" fill="currentColor"/>
+      </marker>
+      <symbol id="ArcPathVisio" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M99.5 50c0 27.338-22.162 49.5-49.5 49.5S.5 77.338.5 50" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Brace" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M1.5 49.5c0-16.167 8.167-24.25 24.5-24.25S50.5 17.167 50.5 1c0 16.167 8.167 24.25 24.5 24.25s24.5 8.083 24.5 24.25" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Complex" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M0 25L25 0h50l25 25v50l-25 25H25L0 75z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Ellipse" overflow="visible" preserveAspectRatio="none" viewBox="0 0 50 50">
+        <ellipse cx="25" cy="25" stroke="currentColor" rx="25" ry="25" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="EndoplasmicReticulum" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M73.528 56.61c-5.625-18.607 23.514-32.434 23.401-45.066-.344-4.861-10.49-8.898-18.29-5.334C61.6 14.085 62.99 35.515 57.435 48.444c-.356 3.61-7.363 2.469-7.75-.487-5.85-11.39 17.136-24.487 5.961-29.426-19.634-8.17-28.752 21.153-22.068 28.818 7.496 14.176-2.18 24.406-6.747 15.496-2.442-5.306 6.066-11.084-.803-16.177-4.32-2.8-11.756-.646-16.155 3.094C-3.019 60.5 14.602 90.744 30.837 85.91c4.698-1.96-3.236-8.702 3.907-9.6 7.298-.812 5.176 6.19 7.687 9.227 2.307 4.051 4.833 8.355 10.763 11.624 4.786 2.537 15.294 2.112 16.771-1.958 2.032-9.263-26.11-28.359-10.689-31.282 18.556-2.714 4.749 23.846 24.31 29.695 9.502 2.028 15.64-.622 14.813-4.033-2.746-11.263-25.136-22.68-24.964-33.15" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="HexagonPathVisio" overflow="visible" preserveAspectRatio="none" viewBox="0 8 100 86">
+        <path stroke="currentColor" d="M1.42 50.996l21.073-42.14h56.191l21.067 42.14-21.067 42.145H22.493L1.42 50.996z" transform="scale(1 .85)" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="GolgiApparatus" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M58.467 27.713c-22.205-29.9 37.31-30.258 25.567-4.823-8.807 18.581-17.066 58.135-.941 99.22 13.314 27.067-41.749 27.761-27.756-1.47 11.346-29.42 10.287-80.336 3.13-92.927z" vector-effect="non-scaling-stroke"/>
+        <path stroke="currentColor" d="M31.214 36.214c-10.791-21.428 29.898-19.848 18.408.671-4.067 7.423-5.783 61.573 1.16 75.03 8.53 18.596-32.852 19.354-20.5-2.252 6.953-17.358 10.474-52.29.932-73.449z" vector-effect="non-scaling-stroke"/>
+        <path stroke="currentColor" d="M29.804 52.16c1.584 11.476 2.723 16.738-1.483 38.362-3.732 12.99-3.6 16.341-11.732 19.413-6.684 1.659-11.865-9.79-4.794-16.114 4.856-5.623 6.141-10.882 6.66-22.954-.24-9.522.814-15.824-5.368-19.959C5.463 48.713 7 34.373 17.911 37.044c5.85 1.027 10.283 8.562 11.893 15.117z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="MimDegradation" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="49" stroke="currentColor" vector-effect="non-scaling-stroke"/>
+        <path stroke="currentColor" d="M1 1l99 99" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Mitochondria" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <ellipse cx="50" cy="50" stroke="currentColor" rx="50" ry="50"/>
+        <path stroke="currentColor" d="M14.895 26.347c4.364-.741 3.827 17.037 8.183 16.184 8.273.03 2.982-28.149 9.9-28.337 6.967-.187 2.246 29.948 9.204 29.44 7.633-.56.508-32.935 8.137-33.623 7.698-.689 2.919 32.04 10.628 32.225 6.547.16 3.026-27.643 9.56-26.921 7.193.793.665 29.842 7.782 31.667 4.748 1.216 4.42-18.258 9.204-17.44 11.129 7.577 8.628 37.698-2.18 44.644-3.138.699-3.966-10.502-7.113-9.905-5.59 1.059-3.982 22.284-9.603 21.8-5.24-.457-2.226-21.637-7.47-21.73-6.962-.117-3.358 28.924-10.317 28.495-6.14-.376-1.73-24.95-7.825-26.192-5.682-1.157-5.378 22.17-11.027 20.68-6.25-1.644-.47-26.673-6.76-27.865-3.728-.706-2.647 14.4-6.403 14.545-14.016-5.939-15.749-39.708-3.9-47.667z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Octagon" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M0 25L25 0h50l25 25v50l-25 25H25L0 75z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="PentagonPathVisio" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M59.16 99.613L95 50.283 59.16.953 1.169 19.796V80.77z" transform="matrix(.95 0 0 1 8 0)" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="Rectangle" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path stroke="currentColor" d="M0 0h100v100H0z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="RoundedRectangle" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <rect width="100" height="100" stroke="currentColor" rx="15" ry="15" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="SarcoplasmicReticulum" overflow="visible" preserveAspectRatio="none" viewBox="0 0 100 100">
+        <path d="M46.602 1.407C14.23 2.75 10.282 24.177 20.099 39.535c9.318 18.343-18.766 30.15 2.57 49.378 16.82 13.116 46.33 6.105 52.126-8.568 5.899-15.249-10.951-26.027-3.294-40.962 10.854-19.884-.776-38.13-24.9-37.976z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="TrianglePathVisio" overflow="visible" preserveAspectRatio="none" viewBox="0 0 50 50">
+        <path stroke="currentColor" d="M14.5 3.3v43.4L61 25z" vector-effect="non-scaling-stroke"/>
+      </symbol>
+      <symbol id="none" preserveAspectRatio="none" viewBox="0 0 100 100"/>
+    </g>
+  </defs>
+  <g id="WP528" about="WP528" class="Viewport" color="black" name="Name: Acetylcholine Synthesis Organism: Homo sapiens">
+    <rect fill="white" stroke="black" stroke-width="0" fill-opacity="1" height="621.8666666666666px" id="WP528-icon" width="829.0515247108307px" x="0" y="0" transform="matrix(1, 0, 0, 1, 0, 0)" class="Icon"/>
+    <g id="a2634" about="a2634" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="67.2, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="a2634" d="M417.5,100L417.5,173" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+      <g id="c7814" about="c7814" class="Burr Anchor" transform="translate(417.5,129.2)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="c7814-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="ida4253087" about="ida4253087" class="Edge GraphicalLine" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 5.02, 3.01, 0, 0" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="ida4253087" d="M50.47318611987416,483.7013669821241L497.3711882229236,483.7013669821241" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="a2ef2" about="a2ef2" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="101.11888403434318, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="a2ef2" d="M115.0515247108307,213.9484752891693L114.66666666666676,320.86666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+      <g id="c354a" about="c354a" class="Burr Anchor" transform="translate(114.89758149316512,256.71575184016825)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="c354a-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="adb08" about="adb08" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="318.4818086225026, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="adb08" d="M434.51971608832804,339.86666666666673L434.51971608832804,359.86666666666673L718.8015247108307,359.86666666666673L718.8015247108307,339.86666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+      <g id="aa3c1" about="aa3c1" class="Burr Anchor" transform="translate(587.3519647664641,359.86666666666673)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="aa3c1-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="be454" about="be454" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="227.2000056969865, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="be454" d="M114.71819137749738,572.8666666666666L114.66666666666676,339.86666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="bfd1a" about="bfd1a" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="215.0152834768826, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="bfd1a" d="M718.8015247108307,320.86666666666673L718.5515247108307,100.0515247108307" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+      <g id="aa74d" about="aa74d" class="Burr Anchor" transform="translate(718.6635844056659,199.02943440107416)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="aa74d-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="b558b" about="b558b" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="20.747796106342605, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="b558b" d="M686.9484752891697,200.46971608832808L718.6635844056659,199.02943440107418" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="c1f99" about="c1f99" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="254.365141955836, 0" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="c1f99" d="M252.86514195583595,460.58485804416404L252.86514195583595,582.3666666666667L385.4484752891693,582.3666666666667" class="EdgeBody"/>
+      </g>
+      <g id="f846e" about="f846e" class="Burr Anchor" transform="translate(252.86514195583595,516.2037037037037)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="f846e-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+      <g id="e9a18" about="e9a18" class="Burr Anchor" transform="translate(252.86514195583595,582.3666666666667)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="e9a18-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="a9da6" about="a9da6" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="23.2022565482527, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="a9da6" d="M287.0546792849631,517.136382754995L252.86514195583595,516.2037037037037" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="c3c6b" about="c3c6b" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="46.069598905503106, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="c3c6b" d="M417.5,193L418.0515247108307,244.86666666666667" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="c7056" about="c7056" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="227.20144728402477, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="c7056" d="M417.61514195583595,572.8666666666667L418.4363827549947,339.86666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="cd893" about="cd893" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="42.59294116786804, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="cd893" d="M586.4395373291269,413.4518401682442L587.3519647664642,359.86666666666673" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="d02d4" about="d02d4" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="238.82276550998944, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="d02d4" d="M386.2697160883281,330.36666666666673L252.86514195583595,330.36666666666673L252.86514195583595,441.58485804416404" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+      <g id="d7914" about="d7914" class="Burr Anchor" transform="translate(252.86514195583595,391.74994667680187)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="d7914-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+      <g id="a5b14" about="a5b14" class="Burr Anchor" transform="translate(252.86514195583595,330.36666666666673)">
+        <use fill="#141414" stroke-width="0" fill-opacity="1" height="0" id="a5b14-icon" width="0" x="0" y="0" xlink:href="#none" class="Icon"/>
+      </g>
+    </g>
+    <g id="c8f4e" about="c8f4e" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="13.57774033782773, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="c8f4e" d="M277.43638275499467,392.315141955836L252.86514195583595,391.74994667680187" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="d3028" about="d3028" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="211.1484752891693, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="d3028" d="M667.5515247108307,330.36666666666673L450.60304942166135,330.36666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="d82f8" about="d82f8" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="35.318585985119824, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="d82f8" d="M371.18717139852833,128.46971608832806L417.5,129.2" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="dd739" about="dd739" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="51.2012992458432, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="dd739" d="M418.0515247108307,263.8666666666667L418.4363827549947,320.86666666666673" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="e532a" about="e532a" class="Edge Interaction SBO_0000167 SBO_0000393 SBO_0000394 DirectedInteraction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="136.25153405531233, 5.8" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="e532a" d="M638.0515247108307,90.0515247108307L496,90" marker-end="url(#markerEndArrow)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="id2603411f" about="id2603411f" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="93.53180862250252, 0" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="id2603411f" d="M159.33333333333343,330.36666666666673L252.86514195583595,330.36666666666673" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="idacc3128f" about="idacc3128f" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="106.9802839116719, 0" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="idacc3128f" d="M145.88485804416405,582.3666666666666L252.86514195583595,582.3666666666667" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="bea09" about="bea09" class="Edge Interaction" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="19.43891049001303, 11" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="bea09" d="M145.33648790746582,256.7L114.89758149316512,256.71575184016825" marker-end="url(#markerEndMimCatalysis)" class="EdgeBody"/>
+      </g>
+    </g>
+    <g id="a27" about="a27" class="SingleFreeNode Label" color="#000000" name="*Synaptic Cleft*" transform="translate(425.35751840168246,496.1484752891693)">
+      <use fill="transparent" fill-opacity="0" stroke="#000000" stroke-width="0" height="19px" id="a27-icon" width="123.33333333333333px" x="0" y="0" xlink:href="#none" transform="matrix(1, 0, 0, 1, 0, 0)" class="Icon"/>
+      <text id="a27-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="12px" font-style="normal" font-weight="bold" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(61.666666666666664,13.5)">
+        <tspan x="0" y="0">*Synaptic Cleft*</tspan>
+      </text>
+    </g>
+    <g id="ab5" about="ab5" class="SingleFreeNode Label" color="#000000" name="*Cytosol*" transform="translate(431.8333333333333,463.8666666666667)">
+      <use fill="transparent" fill-opacity="0" stroke="#000000" stroke-width="0" height="19px" id="ab5-icon" width="76.33333333333333px" x="0" y="0" xlink:href="#none" transform="matrix(1, 0, 0, 1, 0, 0)" class="Icon"/>
+      <text id="ab5-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="12px" font-style="normal" font-weight="bold" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(38.166666666666664,13.5)">
+        <tspan x="0" y="0">*Cytosol*</tspan>
+      </text>
+    </g>
+    <a id="a69" about="a69" class="SingleFreeNode DataNode Entrez_Gene_5130 GeneProduct Ensembl_ENSG00000161217 P594_ENSG00000161217 P351_5130 HGNC_PCYT1A PCYT1A P353_PCYT1A Wikidata_Q18030396" color="#000000" name="PCYT1A" transform="translate(626.9484752891697,190.46971608832808)" xlink:href="https://tools.wmflabs.org/scholia/Q18030396" target="_blank">
+      <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="a69-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+      <text id="a69-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+        <tspan x="0" y="0">PCYT1A</tspan>
+      </text>
+    </a>
+    <a id="afe" about="afe" class="SingleFreeNode DataNode Entrez_Gene_43 GeneProduct Ensembl_ENSG00000087085 P594_ENSG00000087085 P351_43 HGNC_ACHE ACHE P353_ACHE Wikidata_Q407983" color="#000000" name="ACHE" transform="translate(287.0546792849631,507.136382754995)" xlink:href="https://tools.wmflabs.org/scholia/Q407983" target="_blank">
+      <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="afe-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+      <text id="afe-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+        <tspan x="0" y="0">ACHE</tspan>
+      </text>
+    </a>
+    <a id="b909c" about="b909c" class="SingleFreeNode DataNode HMDB_HMDB0001413 Metabolite ChEBI_16436 ChEBI_CHEBI_16436 P683_16436 P683_CHEBI_16436 HMDB_HMDB01413 P2057_HMDB0001413 P2057_HMDB01413 Wikidata_Q28529682" color="#0000ff" name="Cytidine diphosphate choline" transform="translate(638.0515247108307,80.0515247108307)" xlink:href="https://tools.wmflabs.org/scholia/Q28529682" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="20px" id="b909c-icon" width="161px" x="0" y="0" transform="matrix(0.9938271604938271, 0, 0, 0.9523809523809523, 0.4969135802469111, 0.4761904761904763)" class="Icon"/>
+      <text id="b909c-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(80.5,13)">
+        <tspan x="0" y="0">Cytidine diphosphate choline</tspan>
+      </text>
+    </a>
+    <a id="baec0" about="baec0" class="SingleFreeNode DataNode HMDB_HMDB0060501 Metabolite ChEBI_47767 ChEBI_CHEBI_47767 P683_47767 P683_CHEBI_47767 HMDB_HMDB60501 P2057_HMDB0060501 P2057_HMDB60501 Wikidata_Q27093061" color="#0000ff" name="Phosphatidylethanolamine" transform="translate(339,80)" xlink:href="https://tools.wmflabs.org/scholia/Q27093061" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="20px" id="baec0-icon" width="157px" x="0" y="0" transform="matrix(0.9936708860759493, 0, 0, 0.9523809523809523, 0.49683544303798044, 0.4761904761904763)" class="Icon"/>
+      <text id="baec0-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(78.5,13)">
+        <tspan x="0" y="0">Phosphatidylethanolamine</tspan>
+      </text>
+    </a>
+    <a id="ca8" about="ca8" class="SingleFreeNode DataNode HMDB_HMDB0001565 Metabolite ChEBI_CHEBI_18132 ChEBI_18132 P683_CHEBI_18132 P683_18132 HMDB_HMDB01565 P2057_HMDB0001565 P2057_HMDB01565 Wikidata_Q576895" color="#0000ff" name="Phosphorylcholine" transform="translate(667.5515247108307,320.86666666666673)" xlink:href="https://tools.wmflabs.org/scholia/Q576895" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="ca8-icon" width="102.5px" x="0" y="0" transform="matrix(0.9903381642512077, 0, 0, 0.95, 0.4951690821256065, 0.47499999999999964)" class="Icon"/>
+      <text id="ca8-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(51.25,12.5)">
+        <tspan x="0" y="0">Phosphorylcholine</tspan>
+      </text>
+    </a>
+    <a id="cc9" about="cc9" class="SingleFreeNode DataNode CAS_51-84-3 Metabolite ChEBI_CHEBI_15355 ChEBI_15355 P683_CHEBI_15355 P683_15355 HMDB_HMDB0000895 HMDB_HMDB00895 P2057_HMDB0000895 P2057_HMDB00895 Wikidata_Q180623" color="#0000ff" name="Acetylcholine" transform="translate(215.7818086225026,441.58485804416404)" xlink:href="https://tools.wmflabs.org/scholia/Q180623" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="cc9-icon" width="74.16666666666667px" x="0" y="0" transform="matrix(0.9866962305986696, 0, 0, 0.95, 0.49334811529933376, 0.47499999999999964)" class="Icon"/>
+      <text id="cc9-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(37.083333333333336,12.5)">
+        <tspan x="0" y="0">Acetylcholine</tspan>
+      </text>
+    </a>
+    <a id="d2e" about="d2e" class="SingleFreeNode DataNode CAS_62-49-7 Metabolite ChEBI_CHEBI_15354 ChEBI_15354 P683_CHEBI_15354 P683_15354 HMDB_HMDB0000097 HMDB_HMDB00097 P2057_HMDB0000097 P2057_HMDB00097 Wikidata_Q193166" color="#0000ff" name="Choline" transform="translate(385.4484752891693,572.8666666666667)" xlink:href="https://tools.wmflabs.org/scholia/Q193166" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="d2e-icon" width="64.33333333333333px" x="0" y="0" transform="matrix(0.9846938775510204, 0, 0, 0.95, 0.4923469387755084, 0.47499999999999964)" class="Icon"/>
+      <text id="d2e-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(32.166666666666664,12.5)">
+        <tspan x="0" y="0">Choline</tspan>
+      </text>
+    </a>
+    <g id="d6e" about="d6e" class="SingleFreeNode DataNode CAS_28319-77-9 Metabolite ChEBI_CHEBI_16870 ChEBI_16870 P683_CHEBI_16870 P683_16870 HMDB_HMDB0000086 HMDB_HMDB00086 P2057_HMDB0000086 P2057_HMDB00086 Wikidata_Q60476027 Wikidata_Q28529699" color="#0000ff" name="Glycerophosphocholine" transform="translate(352.0515247108307,244.86666666666667)">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="d6e-icon" width="132px" x="0" y="0" transform="matrix(0.9924812030075187, 0, 0, 0.95, 0.49624060150375726, 0.47499999999999964)" class="Icon"/>
+      <text id="d6e-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(66,12.5)">
+        <tspan x="0" y="0">Glycerophosphocholine</tspan>
+      </text>
+    </g>
+    <a id="ddaf4" about="ddaf4" class="SingleFreeNode DataNode HMDB_HMDB0000564 Metabolite ChEBI_72999 ChEBI_CHEBI_72999 P683_72999 P683_CHEBI_72999 HMDB_HMDB00564 P2057_HMDB0000564 P2057_HMDB00564 Wikidata_Q2587934" color="#0000ff" name="Phosphatidylcholine" transform="translate(355,173)" xlink:href="https://tools.wmflabs.org/scholia/Q2587934" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="20px" id="ddaf4-icon" width="125px" x="0" y="0" transform="matrix(0.9920634920634921, 0, 0, 0.9523809523809523, 0.49603174603174693, 0.4761904761904763)" class="Icon"/>
+      <text id="ddaf4-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(62.5,13)">
+        <tspan x="0" y="0">Phosphatidylcholine</tspan>
+      </text>
+    </a>
+    <a id="dfde2" about="dfde2" class="SingleFreeNode DataNode HMDB_HMDB0000243 Metabolite ChEBI_32816 ChEBI_CHEBI_32816 P683_32816 P683_CHEBI_32816 HMDB_HMDB00243 P2057_HMDB0000243 P2057_HMDB00243 Wikidata_Q213580" color="#0000ff" name="Pyruvate from Glycolysis" transform="translate(38.051524710830705,193.9484752891693)" xlink:href="https://tools.wmflabs.org/scholia/Q213580" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="20px" id="dfde2-icon" width="154px" x="0" y="0" transform="matrix(0.9935483870967742, 0, 0, 0.9523809523809523, 0.49677419354839003, 0.4761904761904763)" class="Icon"/>
+      <text id="dfde2-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(77,13)">
+        <tspan x="0" y="0">Pyruvate from Glycolysis</tspan>
+      </text>
+    </a>
+    <g id="dfe" about="dfe" class="SingleFreeNode DataNode CAS_72-89-9 Metabolite ChEBI_15351 ChEBI_CHEBI_57288 ChEBI_CHEBI_15351 ChEBI_57288 P683_15351 P683_CHEBI_15351 P683_57288 P683_CHEBI_57288 HMDB_HMDB01206 HMDB_HMDB0001206 P2057_HMDB01206 P2057_HMDB0001206 Wikidata_Q27124397 Wikidata_Q715317" color="#0000ff" name="Acetyl CoA" transform="translate(70.00000000000009,320.86666666666673)">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="dfe-icon" width="89.33333333333333px" x="0" y="0" transform="matrix(0.988929889298893, 0, 0, 0.95, 0.4944649446494438, 0.47499999999999964)" class="Icon"/>
+      <text id="dfe-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(44.666666666666664,12.5)">
+        <tspan x="0" y="0">Acetyl CoA</tspan>
+      </text>
+    </g>
+    <a id="e2a" about="e2a" class="SingleFreeNode DataNode Entrez_Gene_10400 GeneProduct Ensembl_ENSG00000133027 P594_ENSG00000133027 P351_10400 HGNC_PEMT PEMT P353_PEMT Wikidata_Q14911536" color="#000000" name="PEMT" transform="translate(311.18717139852833,118.46971608832806)" xlink:href="https://tools.wmflabs.org/scholia/Q14911536" target="_blank">
+      <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="e2a-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+      <text id="e2a-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+        <tspan x="0" y="0">PEMT</tspan>
+      </text>
+    </a>
+    <a id="e42" about="e42" class="SingleFreeNode DataNode CAS_64-19-7 Metabolite ChEBI_CHEBI_15366 ChEBI_15366 P683_CHEBI_15366 P683_15366 HMDB_HMDB0000042 HMDB_HMDB00042 P2057_HMDB0000042 P2057_HMDB00042 Wikidata_Q47512" color="#0000ff" name="Acetate" transform="translate(83.5515247108307,572.8666666666666)" xlink:href="https://tools.wmflabs.org/scholia/Q47512" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="e42-icon" width="62.333333333333336px" x="0" y="0" transform="matrix(0.9842105263157894, 0, 0, 0.95, 0.49210526315789593, 0.47499999999999964)" class="Icon"/>
+      <text id="e42-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(31.166666666666668,12.5)">
+        <tspan x="0" y="0">Acetate</tspan>
+      </text>
+    </a>
+    <a id="ea5" about="ea5" class="SingleFreeNode DataNode Entrez_Gene_1119 GeneProduct Ensembl_ENSG00000110721 P594_ENSG00000110721 P351_1119 HGNC_CHKA CHKA P353_CHKA Wikidata_Q17861828" color="#000000" name="CHKA" transform="translate(556.4395373291269,413.4518401682442)" xlink:href="https://tools.wmflabs.org/scholia/Q17861828" target="_blank">
+      <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="ea5-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+      <text id="ea5-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+        <tspan x="0" y="0">CHKA</tspan>
+      </text>
+    </a>
+    <a id="f01" about="f01" class="SingleFreeNode DataNode Entrez_Gene_1103 GeneProduct Ensembl_ENSG00000070748 P594_ENSG00000070748 P351_1103 HGNC_CHAT CHAT P353_CHAT Wikidata_Q14863671" color="#000000" name="CHAT" transform="translate(277.43638275499467,382.315141955836)" xlink:href="https://tools.wmflabs.org/scholia/Q14863671" target="_blank">
+      <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="f01-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+      <text id="f01-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+        <tspan x="0" y="0">CHAT</tspan>
+      </text>
+    </a>
+    <a id="f74" about="f74" class="SingleFreeNode DataNode CAS_62-49-7 Metabolite ChEBI_CHEBI_15354 ChEBI_15354 P683_CHEBI_15354 P683_15354 HMDB_HMDB0000097 HMDB_HMDB00097 P2057_HMDB0000097 P2057_HMDB00097 Wikidata_Q193166" color="#0000ff" name="Choline" transform="translate(386.26971608832804,320.86666666666673)" xlink:href="https://tools.wmflabs.org/scholia/Q193166" target="_blank">
+      <rect fill="#ffffff" stroke="#0000ff" stroke-width="1" fill-opacity="1" height="19px" id="f74-icon" width="64.33333333333333px" x="0" y="0" transform="matrix(0.9846938775510204, 0, 0, 0.95, 0.4923469387755084, 0.47499999999999964)" class="Icon"/>
+      <text id="f74-text" class="Text" direction="ltr" fill="#0000ff" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(32.166666666666664,12.5)">
+        <tspan x="0" y="0">Choline</tspan>
+      </text>
+    </a>
+    <g id="d74e5" about="d74e5" class="Group GroupNone" color="#808080" transform="translate(144.33648790746582,227.7)">
+      <rect fill="#b4b464" fill-opacity="0.1" stroke="#808080" stroke-dasharray="5,3" stroke-width="1" height="58px" id="d74e5-icon" width="78px" x="0" y="0" transform="matrix(0.9873417721518988, 0, 0, 0.9830508474576272, 0.49367088607594667, 0.49152542372881314)" class="Icon"/>
+      <a id="a93" about="a93" class="SingleFreeNode DataNode Entrez_Gene_5161 GeneProduct Ensembl_ENSG00000163114 P594_ENSG00000163114 P351_5161 HGNC_PDHA2 PDHA2 P353_PDHA2 Wikidata_Q18030428" color="#000000" name="PDHA2" transform="translate(9,29)" xlink:href="https://tools.wmflabs.org/scholia/Q18030428" target="_blank">
+        <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="a93-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+        <text id="a93-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+          <tspan x="0" y="0">PDHA2</tspan>
+        </text>
+      </a>
+      <a id="ba5" about="ba5" class="SingleFreeNode DataNode Entrez_Gene_5160 GeneProduct Ensembl_ENSG00000131828 P594_ENSG00000131828 P351_5160 HGNC_PDHA1 PDHA1 P353_PDHA1 Wikidata_Q18030427" color="#000000" name="PDHA1" transform="translate(9,9)" xlink:href="https://tools.wmflabs.org/scholia/Q18030427" target="_blank">
+        <rect fill="#ffffff" stroke="#000000" stroke-width="1" fill-opacity="1" height="20px" id="ba5-icon" width="60px" x="0" y="0" transform="matrix(0.9836065573770492, 0, 0, 0.9523809523809523, 0.4918032786885256, 0.4761904761904763)" class="Icon"/>
+        <text id="ba5-text" class="Text" direction="ltr" fill="#000000" font-family="'Liberation Sans', Arial, sans-serif" font-size="10px" font-style="normal" font-weight="normal" stroke="white" stroke-width="0px" text-anchor="middle" transform="translate(30,13)">
+          <tspan x="0" y="0">PDHA1</tspan>
+        </text>
+      </a>
+    </g>
+    <g id="abb02" about="abb02" class="Edge GraphicalLine" color="#000000">
+      <g filter="url(#kaavioblackto000000filter)" color="#000000" fill="transparent" fill-opacity="0" stroke="black" stroke-dasharray="5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 5.09, 3.05, 0, 0" stroke-width="1">
+        <path style="color:inherit;fill:inherit;fill-opacity:inherit;stroke:inherit;stroke-width:inherit" id="abb02" d="M52.06098843322886,492.64984227129344L496.8559411146157,492.64984227129344" class="EdgeBody"/>
+      </g>
+    </g>
+    <text id="WP528-text" class="Text" direction="ltr" dominant-baseline="central" fill="black" font-family="'Liberation Sans', Arial, sans-serif" font-size="12px" font-style="normal" font-weight="bold" overflow="visible" stroke="white" stroke-width="0px" text-anchor="start" transform="translate(5,27)">
+      <tspan x="0" y="-9">Name: Acetylcholine Synthesis</tspan>
+      <tspan x="0" y="9">Organism: Homo sapiens</tspan>
+    </text>
+  </g>
+</svg>
+
+<script src="/pathway-viewer/static/svg-pan-zoom.min.js"></script><script>svgPanZoom("svg")</script></body></html>

--- a/tools/pathway-viewer/view_pathway.R
+++ b/tools/pathway-viewer/view_pathway.R
@@ -1,0 +1,98 @@
+suppressPackageStartupMessages({
+    library(RCurl)
+    library(RColorBrewer)
+    library(rWikiPathways)
+    library(RCy3)
+    library(optparse)
+})
+
+# inputs
+option_list <- list(
+    make_option(c("-p", "--wikiPathway"),
+                type = "character",
+                default = 'WP528',
+                help = "wikiPathway Identtifier",
+                metavar = "character"),
+    make_option(c("-g", "--genes"),
+                type = "character",
+                help = "Path to differentially expressed genes file",
+                metavar = "character"),
+    make_option(c("-l", "--header"),
+                type = "logical",
+                help = "File has header line?",
+                metavar = "logical")
+    )
+
+opt_parser <- OptionParser(usage = "%prog [options] file",
+                           option_list = option_list)
+opt <- parse_args(opt_parser)
+
+wp_id <- opt$wikiPathway
+headers <- opt$header
+input_data <- opt$genes
+
+
+#fetch and modify data
+dat <- read.table(input_data, header = headers, sep="\t", fill=TRUE)
+if(headers)
+{
+  colnames(dat)[1] <- "geneid"
+  colnames(dat)[2] <- "fc"
+} else
+{
+  colnames(dat) <- c("geneid", "fc", "p-value", "adj p-value")
+}
+
+dat <- data.frame(lapply(dat, function(v) {
+  if (is.character(v)) return(toupper(v))
+  else return(v)
+}))
+min.fc = min(dat["fc"],na.rm=TRUE)
+max.fc = max(dat["fc"],na.rm=TRUE)
+abs.fc = max(abs(min.fc),abs(max.fc))
+data.values = c(-abs.fc,0,abs.fc)
+
+#open in browser
+rgb2hex <- function(r,g,b) rgb(r, g, b, maxColorValue = 255)
+fill_hex <- function(x) {
+  out <- vector(mode="character", length=length(x))
+  for (i in seq_along(x))
+  {
+    if(is.na(x[[i]]))
+    {
+      out[[i]] <- "#ffffff"
+    }
+    else
+    {
+      rel_value = 70+(185*( 1 - (abs(x[[i]])/abs.fc)))
+      if(x[[i]] < 0)
+      {
+        if(abs(min.fc) == 0)
+        {
+          out[[i]] <- "#ffffff"
+        }
+        else{
+          out[[i]] <- rgb2hex(rel_value, rel_value, 255)
+        }
+      }
+      else
+      {
+        if(abs(min.fc) == 0)
+        {
+          out[[i]] <- "#ffffff"
+        }
+        else{
+          out[[i]] <- rgb2hex(255, rel_value, rel_value)
+        }
+      }
+    }
+
+
+  }
+  return(out)
+}
+dat$hex <- fill_hex(dat[["fc"]])
+url_params <- paste(with(dat, paste(substr(hex,2,nchar(hex)), geneid, sep="=HGNC_")), collapse="&")
+url <- paste("https://pathway-viewer.toolforge.org/?id=", wp_id, "&", url_params, sep="")
+download.file(url, destfile='pathwayview.html', method="libcurl")
+


### PR DESCRIPTION
Part of BioHackathon 2020

Add the pathway viewer tool from wikipathways in Galaxy

TODOs:
- [ ] use list of pathways instead of manually supplied pathway id
- [ ] update help text


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/erasmusmc-bioinformatics/galaxytools-emc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `erasmus-medical-center` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
